### PR TITLE
Using exported json executable to avoid unnecessarily extending PATH

### DIFF
--- a/bin/awsudo
+++ b/bin/awsudo
@@ -12,12 +12,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-JSON_LIB_PATH=${DIR/%\/bin//}
 # END RESOLVE SCRIPT PATH
-
-# ADD JSON TO PATH
-PATH=$PATH:${JSON_LIB_PATH}/node_modules/json/lib
-# END ADD JSON TO PATH
 
 ROLE_ARN=$1
 shift
@@ -33,9 +28,9 @@ fi
 CREDENTIALS=`aws sts assume-role --role-arn ${ROLE_ARN} --role-session-name RoleSession --duration-seconds 900 --output=json`
 
 # Set AWS Assumed Role Credentials on ENV
-export AWS_ACCESS_KEY_ID=`echo "${CREDENTIALS}" | json.js Credentials.AccessKeyId`
-export AWS_SECRET_ACCESS_KEY=`echo "${CREDENTIALS}" | json.js Credentials.SecretAccessKey`
-export AWS_SESSION_TOKEN=`echo "${CREDENTIALS}" | json.js Credentials.SessionToken`
-export AWS_EXPIRATION=`echo "${CREDENTIALS}" | json.js Credentials.Expiration`
+export AWS_ACCESS_KEY_ID=`echo "${CREDENTIALS}" | json Credentials.AccessKeyId`
+export AWS_SECRET_ACCESS_KEY=`echo "${CREDENTIALS}" | json Credentials.SecretAccessKey`
+export AWS_SESSION_TOKEN=`echo "${CREDENTIALS}" | json Credentials.SessionToken`
+export AWS_EXPIRATION=`echo "${CREDENTIALS}" | json Credentials.Expiration`
 
 eval $@

--- a/bin/awsudo
+++ b/bin/awsudo
@@ -33,9 +33,9 @@ fi
 CREDENTIALS=`aws sts assume-role --role-arn ${ROLE_ARN} --role-session-name RoleSession --duration-seconds 900 --output=json`
 
 # Set AWS Assumed Role Credentials on ENV
-export AWS_ACCESS_KEY_ID=`echo ${CREDENTIALS} | json.js Credentials.AccessKeyId`
-export AWS_SECRET_ACCESS_KEY=`echo ${CREDENTIALS} | json.js .Credentials.SecretAccessKey`
-export AWS_SESSION_TOKEN=`echo ${CREDENTIALS} | json.js Credentials.SessionToken`
-export AWS_EXPIRATION=`echo ${CREDENTIALS} | json.js Credentials.Expiration`
+export AWS_ACCESS_KEY_ID=`echo "${CREDENTIALS}" | json.js Credentials.AccessKeyId`
+export AWS_SECRET_ACCESS_KEY=`echo "${CREDENTIALS}" | json.js Credentials.SecretAccessKey`
+export AWS_SESSION_TOKEN=`echo "${CREDENTIALS}" | json.js Credentials.SessionToken`
+export AWS_EXPIRATION=`echo "${CREDENTIALS}" | json.js Credentials.Expiration`
 
 eval $@

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "preversion": "npm test",
+    "start": "bin/awsudo",
     "test": "npm outdated && nsp check",
     "postversion": "git push --follow-tags"
   },


### PR DESCRIPTION
On closer inspection, it appears the only reason we needed to append the JSON package's internal lib folder to the PATH environment variable is because we were referring to their executable by its internal name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/meltwater/awsudo/9)
<!-- Reviewable:end -->
