### PR TITLE
Adjust to parsing argv before yargs to get complete aws command without the need for '--' delimeter

### DIFF
--- a/bin/awsudo
+++ b/bin/awsudo
@@ -3,11 +3,20 @@
 const AWS = require("aws-sdk");
 const { execSync } = require("child_process");
 
-const argv = require("yargs")
-  .parserConfiguration({
-    // By default, `yargs` stops parsing after `--`. This option stores unparsed arguments into argv["--"].
-    "populate--": true
-  })
+function parseArgvForAwsCommand() {
+    const argvArray = Array.from(process.argv).slice(2);
+    const arn = argvArray.find((option) => option.startsWith('arn:'));
+    const arnPosition = argvArray.indexOf(arn);
+    const awsudoOptions = argvArray.slice(0, arnPosition + 2);
+    const awsCommand = argvArray.slice(arnPosition + 1, argvArray.length);
+
+    return {
+        awsudoOptions,
+        awsCommand
+    };
+}
+
+const argv = require("yargs")(parseArgvForAwsCommand().awsudoOptions)
   .usage(
     "$0 [-d|--duration] [-v|--verbose] <arn> <command..>",
     "Assume an IAM role for the duration of a command",
@@ -70,10 +79,8 @@ if (!/^arn:aws:iam/.test(argv.arn)) {
     ["AWS_EXPIRATION", credentials.Expiration.toISOString()]
   ]
     .map(arr => arr.join("="))
-    .concat(argv.command);
-  if (argv["--"]) {
-    commandArgs = commandArgs.concat("--", argv["--"]);
-  }
+    .concat(parseArgvForAwsCommand().awsCommand);
+
   const command = commandArgs.join(" ");
 
   if (argv.verbose) {

--- a/bin/awsudo
+++ b/bin/awsudo
@@ -3,11 +3,13 @@
 const AWS = require("aws-sdk");
 const { execSync } = require("child_process");
 
+const REMOVE_NODE_COMMANDS = 2;
+const ARN_PLUS_NEXT_COMMAND = 2;
 function parseArgvForAwsCommand() {
-    const argvArray = Array.from(process.argv).slice(2);
+    const argvArray = Array.from(process.argv).slice(REMOVE_NODE_COMMANDS);
     const arn = argvArray.find((option) => option.startsWith('arn:'));
     const arnPosition = argvArray.indexOf(arn);
-    const awsudoOptions = argvArray.slice(0, arnPosition + 2);
+    const awsudoOptions = argvArray.slice(0, arnPosition + ARN_PLUS_NEXT_COMMAND);
     const awsCommand = argvArray.slice(arnPosition + 1, argvArray.length);
 
     return {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/meltwater/awsudo/27)
<!-- Reviewable:end -->
