### PR TITLE
Only show stack trace if verbose mode is enabled

### DIFF
--- a/bin/awsudo
+++ b/bin/awsudo
@@ -123,6 +123,8 @@ if (!/^arn:aws:iam/.test(argv.arn)) {
 
   execSync(command, { stdio: "inherit" });
 })().catch(err => {
-  console.log("Caught runtime exception:", err);
+  if (argv.verbose) { 
+    console.log("Caught runtime exception:", err);
+  }
   process.exit(1);
 });


### PR DESCRIPTION
In reference to Issue #34, this should help with the credential masking.  This will only dump the stack trace if the user specifically requested the `-v` flag enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/meltwater/awsudo/39)
<!-- Reviewable:end -->
