### PR TITLE
Adding a profile flag. Basic Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For more information about the motiviation behind developing this utility, pleas
 ## Usage
 
 ```bash
-awsudo [-d|--duration] [-n|--session-name] [-e|--external-id] [-v|--verbose]
+awsudo [-d|--duration] [-p|--profile] [-n|--session-name] [-e|--external-id] [-v|--verbose]
 [-m|--mfa-token-arn] [-t|--mfa-token] <arn> <command..>
 
 Assume an IAM role for the duration of a command
@@ -25,6 +25,8 @@ Options:
                        https://docs.aws.amazon.com/STS/latest/APIReference/API_A
                        ssumeRole.html#API_AssumeRole_RequestParameters
                                                          [number] [default: 900]
+  -p, --profile       The profile used to assume the role
+                                                          [string] [default: ""]
   -n, --session-name   The role session name to use
                                                [string] [default: "RoleSession"]
   -e, --external-id    The external id string used to authenticate role
@@ -95,15 +97,17 @@ These can be downloaded from
 1. the [releases tab](https://github.com/meltwater/awsudo/releases) in your browser
 2. the command-line:
 
-    **Latest .deb**
-    ```bash
-    curl -LO $(curl -s https://api.github.com/repos/meltwater/awsudo/releases/latest | grep -Eo 'https://github\.com/meltwater/awsudo/releases/download/v.*\.deb')
-    ```
+   **Latest .deb**
 
-    **Latest .rpm**
-    ```bash
-    curl -LO $(curl -s https://api.github.com/repos/meltwater/awsudo/releases/latest | grep -Eo 'https://github\.com/meltwater/awsudo/releases/download/v.*\.rpm')
-    ```
+   ```bash
+   curl -LO $(curl -s https://api.github.com/repos/meltwater/awsudo/releases/latest | grep -Eo 'https://github\.com/meltwater/awsudo/releases/download/v.*\.deb')
+   ```
+
+   **Latest .rpm**
+
+   ```bash
+   curl -LO $(curl -s https://api.github.com/repos/meltwater/awsudo/releases/latest | grep -Eo 'https://github\.com/meltwater/awsudo/releases/download/v.*\.rpm')
+   ```
 
 ### Example usages
 

--- a/bin/awsudo
+++ b/bin/awsudo
@@ -20,7 +20,7 @@ function parseArgvForAwsCommand() {
 
 const argv = require("yargs")(parseArgvForAwsCommand().awsudoOptions)
   .usage(
-    "$0 [-d|--duration] [-n|--session-name] [-e|--external-id] [-v|--verbose] [-m|--mfa-token-arn] [-t|--mfa-token] <arn> <command..>",
+    "$0 [-d|--duration] [-p|--profile] [-n|--session-name] [-e|--external-id] [-v|--verbose] [-m|--mfa-token-arn] [-t|--mfa-token] <arn> <command..>",
     "Assume an IAM role for the duration of a command",
     yargs => {
       yargs
@@ -30,6 +30,12 @@ const argv = require("yargs")(parseArgvForAwsCommand().awsudoOptions)
             "The duration to assume this role in seconds. See https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html#API_AssumeRole_RequestParameters",
           default: 900,
           type: "number"
+        })
+        .option("p", {
+          alias: "profile",
+          describe: "The profile used to assume the role",
+          default: "",
+          type: "string"
         })
         .option("n", {
           alias: "session-name",
@@ -82,6 +88,7 @@ if (!/^arn:aws:iam/.test(argv.arn)) {
 }
 
 (async () => {
+  let command;
   let credentials;
   const stsOptions = {};
 
@@ -106,6 +113,10 @@ if (!/^arn:aws:iam/.test(argv.arn)) {
         return;
     }
 
+    if (argv.profile) {
+      AWS.config.credentials = new AWS.SharedIniFileCredentials({ profile: argv.profile });
+    }
+
     const sts = new AWS.STS(stsOptions);
     const data = await sts
       .assumeRole(assumeRoleParameters)
@@ -122,10 +133,17 @@ if (!/^arn:aws:iam/.test(argv.arn)) {
     ["AWS_SESSION_TOKEN", credentials.SessionToken],
     ["AWS_EXPIRATION", credentials.Expiration.toISOString()]
   ]
-    .map(arr => arr.join("="))
-    .concat(parseArgvForAwsCommand().awsCommand);
+    .map(arr => arr.join("="));
 
-  const command = commandArgs.join(" ");
+  if (process.platform === "win32") {
+    command = commandArgs
+      .map((arr) => `SET "${arr}"`)
+      .concat(parseArgvForAwsCommand().awsCommand.join(" "))
+      .join(" & ");
+  }
+  else {
+    command = commandArgs.concat(parseArgvForAwsCommand().awsCommand).join(" ");
+  }
 
   if (argv.verbose) {
     console.log(`Running command ${command}`);


### PR DESCRIPTION
This PR adds the ability to specify a profile while assuming a role. This is useful when the user has no default credentials configured or would like to use a specific profile.

Also adds basic Windows support by formatting the command to run on a Windows computer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/meltwater/awsudo/51)
<!-- Reviewable:end -->
