### PR TITLE
Quote command arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@eslint/eslintrc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.3.tgz",
-      "integrity": "sha512-DHI1wDPoKCBPoLZA3qDR91+3te/wDSc1YhKg3jR8NxKKRJq2hwHwcWv31cSwSYvIBrmbENoYMWcenW8uproQqg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.4.tgz",
+      "integrity": "sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -16,21 +16,9 @@
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -45,9 +33,9 @@
       }
     },
     "@humanwhocodes/object-schema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
     "@sindresorhus/is": {
@@ -140,18 +128,15 @@
       }
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "aws-sdk": {
-      "version": "2.1023.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1023.0.tgz",
-      "integrity": "sha512-RAI8sUfK+00yL9i3xz5kbM3+t/0mjjnKhKyauXAlJN4seDYtIX5+BqMghpkZwvLBdi6idXIuz+FHWETHZccyuA==",
+      "version": "2.1028.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1028.0.tgz",
+      "integrity": "sha512-OmR0NcpU8zsDcUOZhM+eZ6CzlUFtuaEuRyjm6mxDO0KI7lJAp7/NzB6tcellRrgWxL+NO7b5TSxi+m28qu5ocQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -511,12 +496,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.1.0.tgz",
-      "integrity": "sha512-JZvNneArGSUsluHWJ8g8MMs3CfIEzwaLx9KyH4tZ2i+R2/rPWzL8c0zg3rHdwYVpN/1sB9gqnjHwz9HoeJpGHw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.2.0.tgz",
+      "integrity": "sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.0.3",
+        "@eslint/eslintrc": "^1.0.4",
         "@humanwhocodes/config-array": "^0.6.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -550,10 +535,21 @@
         "progress": "^2.0.0",
         "regexpp": "^3.2.0",
         "semver": "^7.2.1",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "eslint-scope": {
@@ -584,9 +580,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
-      "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
       "dev": true
     },
     "espree": {
@@ -599,12 +595,6 @@
         "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^3.0.0"
       }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
     },
     "esquery": {
       "version": "1.4.0",
@@ -688,9 +678,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
     },
     "fs.realpath": {
@@ -994,14 +984,6 @@
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        }
       }
     },
     "json-buffer": {
@@ -1128,20 +1110,20 @@
       "dev": true
     },
     "nodemon": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.14.tgz",
-      "integrity": "sha512-frcpDx+PviKEQRSYzwhckuO2zoHcBYLHI754RE9z5h1RGtrngerc04mLpQQCPWBkH/2ObrX7We9YiwVSYZpFJQ==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.15.tgz",
+      "integrity": "sha512-gdHMNx47Gw7b3kWxJV64NI+Q5nfl0y5DgDbiVtShiwa7Z0IZ07Ll4RLFo6AjrhzMtoEZn5PDE3/c2AbVsiCkpA==",
       "dev": true,
       "requires": {
-        "chokidar": "^3.2.2",
-        "debug": "^3.2.6",
+        "chokidar": "^3.5.2",
+        "debug": "^3.2.7",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.7",
+        "pstree.remy": "^1.1.8",
         "semver": "^5.7.1",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
-        "undefsafe": "^2.0.3",
+        "undefsafe": "^2.0.5",
         "update-notifier": "^5.1.0"
       },
       "dependencies": {
@@ -1465,12 +1447,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
       "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
-      "dev": true
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "string-width": {

--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
   },
   "homepage": "https://github.com/meltwater/awsudo#readme",
   "dependencies": {
-    "aws-sdk": "2.1023.0",
+    "aws-sdk": "2.1028.0",
     "yargs": "17.2.1"
   },
   "devDependencies": {
-    "eslint": "8.1.0",
+    "eslint": "8.2.0",
     "jasmine": "3.10.0",
     "mustache": "4.2.0",
-    "nodemon": "2.0.14"
+    "nodemon": "2.0.15"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,13 @@ function extractPositionalOptions (positionals) {
     };
 }
 
-const yargsv = require("yargs")(process.argv.slice(2))
+function quoteCommandArguments (argv) {
+    const commandIndex = argv.findIndex(arg => !arg.startsWith('-') && !isRoleArn(arg));
+
+    return argv.slice(0, commandIndex).concat(`"${argv.slice(commandIndex).join(' ')}"`);
+}
+
+const yargsv = require("yargs")(quoteCommandArguments(process.argv.slice(2)))
     .usage(
         "$0 [-d|--duration] [-p|--profile] [-n|--session-name] [-e|--external-id] [-v|--verbose] [-m|--mfa-token-arn] [-t|--mfa-token] [arn] <command..>",
         "Assume an IAM role for the duration of a command",


### PR DESCRIPTION
yargs was greedily interpreting any options as meant for it. This broke the previous (and intended) behavior of allowing a literal shell command as the final argument array.

This resolves the issue by enclosing the command and its arguments into a single argument as yargs will interpret it using quotes

This is meant to fix #58